### PR TITLE
There seems to be a bug in our unapplySeq when there are no numbers.

### DIFF
--- a/src/test/scala/com/ora/scalabeyondbasics/AdvancedPatternMatchingSpec.scala
+++ b/src/test/scala/com/ora/scalabeyondbasics/AdvancedPatternMatchingSpec.scala
@@ -510,7 +510,8 @@ class AdvancedPatternMatchingSpec extends FunSpec with Matchers {
         def unapplySeq(x:String):Option[Seq[String]] = {
            val regex = """\d+""".r
            val matches = regex.findAllIn(x)
-           if (matches.isEmpty) None else Some(matches.toSeq)
+	   Some(matches.toSeq)
+//           if (matches.isEmpty) None else Some(matches.toSeq)
         }
       }
 
@@ -522,6 +523,15 @@ class AdvancedPatternMatchingSpec extends FunSpec with Matchers {
       }
 
       result should be ("Two numbers: 110, 99")
+
+      val otherResult = "There is no score" match {
+        case (WordNumbers()) => "No numbers in the word"
+        case (WordNumbers(x)) => s"One number: $x"
+        case (WordNumbers(x, y)) => s"Two numbers: $x, $y"
+        case (WordNumbers(x, y, z@_*)) => s"Two or more numbers: $x, $y, and the rest is $z"
+      }
+
+      otherResult should be ("No numbers in the word")
     }
   }
 


### PR DESCRIPTION
Our match statement seem to have a case for strings without any numbers.
But this case did not work as we implemented the `unapplySeq`. I think
we shouldn't return a `None` in that case but a `Some` of an empty
sequence.